### PR TITLE
octavia: Parameterize amphora mgmt network

### DIFF
--- a/api/v1beta1/octavia_types.go
+++ b/api/v1beta1/octavia_types.go
@@ -50,6 +50,9 @@ type OctaviaSpec struct {
 
 type OctaviaAmphoraSpec struct {
 	ImageURL string `json:"imageURL"`
+
+	// +optional
+	ManagementCIDR string `json:"managementCIDR"`
 }
 
 type OctaviaAPISpec struct {

--- a/api/v1beta1/octavia_webhook.go
+++ b/api/v1beta1/octavia_webhook.go
@@ -23,7 +23,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 )
 
-// log is for logging in this package.
 var octavialog = logf.Log.WithName("octavia-resource")
 
 func (r *Octavia) SetupWebhookWithManager(mgr ctrl.Manager) error {
@@ -31,8 +30,6 @@ func (r *Octavia) SetupWebhookWithManager(mgr ctrl.Manager) error {
 		For(r).
 		Complete()
 }
-
-// EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 
 //+kubebuilder:webhook:path=/mutate-openstack-ospk8s-com-v1beta1-octavia,mutating=true,failurePolicy=fail,sideEffects=None,groups=openstack.ospk8s.com,resources=octavias,verbs=create;update,versions=v1beta1,name=moctavia.kb.io,admissionReviewVersions={v1,v1beta1}
 
@@ -44,9 +41,12 @@ func (r *Octavia) Default() {
 
 	r.Spec.Broker = brokerDefault(r.Spec.Broker, r.Name, defaultVirtualHost)
 	r.Spec.Database = databaseDefault(r.Spec.Database, r.Name)
+
+	if r.Spec.Amphora.ManagementCIDR == "" {
+		r.Spec.Amphora.ManagementCIDR = "172.28.0.0/24"
+	}
 }
 
-// TODO(user): change verbs to "verbs=create;update;delete" if you want to enable deletion validation.
 //+kubebuilder:webhook:path=/validate-openstack-ospk8s-com-v1beta1-octavia,mutating=false,failurePolicy=fail,sideEffects=None,groups=openstack.ospk8s.com,resources=octavias,verbs=create;update,versions=v1beta1,name=voctavia.kb.io,admissionReviewVersions={v1,v1beta1}
 
 var _ webhook.Validator = &Octavia{}
@@ -55,7 +55,6 @@ var _ webhook.Validator = &Octavia{}
 func (r *Octavia) ValidateCreate() error {
 	octavialog.Info("validate create", "name", r.Name)
 
-	// TODO(user): fill in your validation logic upon object creation.
 	return nil
 }
 
@@ -63,7 +62,8 @@ func (r *Octavia) ValidateCreate() error {
 func (r *Octavia) ValidateUpdate(old runtime.Object) error {
 	octavialog.Info("validate update", "name", r.Name)
 
-	// TODO(user): fill in your validation logic upon object update.
+	// TODO amphora managementCIDR should be immutable
+
 	return nil
 }
 
@@ -71,6 +71,5 @@ func (r *Octavia) ValidateUpdate(old runtime.Object) error {
 func (r *Octavia) ValidateDelete() error {
 	octavialog.Info("validate delete", "name", r.Name)
 
-	// TODO(user): fill in your validation logic upon object deletion.
 	return nil
 }

--- a/config/crd/bases/openstack.ospk8s.com_controlplanes.yaml
+++ b/config/crd/bases/openstack.ospk8s.com_controlplanes.yaml
@@ -2081,6 +2081,8 @@ spec:
                     properties:
                       imageURL:
                         type: string
+                      managementCIDR:
+                        type: string
                     required:
                     - imageURL
                     type: object

--- a/config/crd/bases/openstack.ospk8s.com_octavias.yaml
+++ b/config/crd/bases/openstack.ospk8s.com_octavias.yaml
@@ -40,6 +40,8 @@ spec:
                 properties:
                   imageURL:
                     type: string
+                  managementCIDR:
+                    type: string
                 required:
                 - imageURL
                 type: object

--- a/config/samples/openstack_v1beta1_octavia.yaml
+++ b/config/samples/openstack_v1beta1_octavia.yaml
@@ -6,6 +6,7 @@ spec:
   image: ghcr.io/ianunruh/openstack-operator-images/octavia:master
   amphora:
     imageURL: https://tarballs.opendev.org/openstack/octavia/test-images/test-only-amphora-x64-haproxy-ubuntu-focal.qcow2
+    managementCIDR: 192.168.250.0/24
   api:
     replicas: 2
     ingress:

--- a/controllers/octavia_controller.go
+++ b/controllers/octavia_controller.go
@@ -251,6 +251,7 @@ func (r *OctaviaReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&openstackv1beta1.Octavia{}).
 		Owns(&corev1.ConfigMap{}).
+		Owns(&appsv1.DaemonSet{}).
 		Owns(&appsv1.Deployment{}).
 		Owns(&netv1.Ingress{}).
 		Owns(&batchv1.Job{}).

--- a/gate/capi/calico/kustomization.yaml
+++ b/gate/capi/calico/kustomization.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+bases:
+- https://docs.projectcalico.org/v3.18/manifests/calico.yaml
+patchesJson6902:
+- target:
+    kind: DaemonSet
+    version: v1
+    name: calico-node
+  patch: |-
+    - op: add
+      path: /spec/template/spec/containers/0/env/-
+      value:
+        name: IP_AUTODETECTION_METHOD
+        value: cidr=10.12.0.0/24

--- a/gate/capi/controlplane.yaml
+++ b/gate/capi/controlplane.yaml
@@ -89,3 +89,16 @@ spec:
     image: xrally/xrally-openstack:2.1.0
     data:
       capacity: 10Gi
+  octavia:
+    image: ghcr.io/ianunruh/openstack-operator-images/octavia:master
+    amphora:
+      imageURL: https://tarballs.opendev.org/openstack/octavia/test-images/test-only-amphora-x64-haproxy-ubuntu-focal.qcow2
+    healthManager:
+      nodeSelector:
+        openstack/octavia-controller: enabled
+    housekeeping:
+      nodeSelector:
+        openstack/octavia-controller: enabled
+    worker:
+      nodeSelector:
+        openstack/octavia-controller: enabled

--- a/gate/capi/setup.sh
+++ b/gate/capi/setup.sh
@@ -53,7 +53,7 @@ kubectl -n kube-system create secret generic cloud-config --from-file=cloud.conf
 
 # Install cluster networking
 log "Applying Calico networking manifests"
-kubectl apply -f https://docs.projectcalico.org/v3.18/manifests/calico.yaml
+kubectl apply -k calico
 
 log "Applying cloud provider manifests"
 kubectl kustomize cloud-provider | \

--- a/pkg/octavia/amphora/bootstrap.go
+++ b/pkg/octavia/amphora/bootstrap.go
@@ -327,7 +327,7 @@ func (b *bootstrap) EnsureNetwork(ctx context.Context) error {
 	_, err = subnets.Create(b.network, subnets.CreateOpts{
 		NetworkID: network.ID,
 		IPVersion: gophercloud.IPv4,
-		CIDR:      "192.168.250.0/24",
+		CIDR:      b.instance.Spec.Amphora.ManagementCIDR,
 	}).Extract()
 	if err != nil {
 		return err


### PR DESCRIPTION
Enables Octavia in the CAPI gate test, which required a few changes to work around some networking oddities.

The CAPI gate test utilizes an OpenStack cloud that is running with OVN. The DHCP service provided by ovn-controller does not respect the options requested by the DHCP client in the Octavia health manager pod. This results in incorrect routes getting added to the underlying K8s node, breaking networking for that node. This change adds a hook to the DHCP client that totally ignores certain options from the OVN DHCP server.

The CAPI gate test uses the standard Calico 3.18 install manifest, which configures autodetection to determine the node IP. When the Amphora management network gets added to o-hm0 on the underlying K8s node, that causes the calico-node DaemonSet to switch the node IP to that management network. This breaks Calico networking for the underlying K8s node. This change patches the Calico install to override autodetection to filter the cluster network.